### PR TITLE
解决分享到QQZone成功后不能返回原应用的bug

### DIFF
--- a/Diplomat/ViewController.m
+++ b/Diplomat/ViewController.m
@@ -162,7 +162,7 @@ static enum WXScene kWechatScene = WXSceneSession;
   message.audioUrl = @"http://share.liulishuo.com/v2/share/8a6d90f0dcfa013245d752540071c562";
   message.audioDataUrl = @"http://cdn.llsapp.com/54251c18636d734cc90b4900_Zjk0MWQwMDAwMDBiODdlNQ==_1431672097.mp3";
   message.thumbnailableImage = [UIImage imageNamed:@"IMG_0965_thumb.png"];
-  message.userInfo = @{kWechatSceneTypeKey: @(kWechatScene), kTencentQQSceneType: @(TencentSceneZone)};
+  message.userInfo = @{kWechatSceneTypeKey: @(kWechatScene), kTencentQQSceneTypeKey: @(TencentSceneZone)};
 
   return message;
 }

--- a/Sources/Tencent/QQProxy.m
+++ b/Sources/Tencent/QQProxy.m
@@ -12,7 +12,7 @@
 
 static NSString * const kQQErrorDomain = @"qq_error_domain";
 NSString * const kDiplomatTypeQQ = @"diplomat_qq";
-NSString * const kTencentQQSceneTypeKey = @"diplmat_tencent_qq_scene_type";
+NSString * const kTencentQQSceneTypeKey = @"tencent_qq_scene_type_key";
 
 @interface QQProxy () <QQApiInterfaceDelegate, TencentSessionDelegate>
 @property (copy, nonatomic) DiplomatCompletedBlock block;
@@ -78,7 +78,6 @@ NSString * const kTencentQQSceneTypeKey = @"diplmat_tencent_qq_scene_type";
     self.block = compltetedBlock;
     
     QQApiObject *apiObject = [message qqMessage];
-    apiObject.cflag = kQQAPICtrlFlagQQShare;
     SendMessageToQQReq *request = [SendMessageToQQReq reqWithContent:apiObject];
     
     //区别手机QQ和QZone请求
@@ -88,10 +87,19 @@ NSString * const kTencentQQSceneTypeKey = @"diplmat_tencent_qq_scene_type";
         [message.userInfo[kTencentQQSceneTypeKey] intValue] == TencentSceneZone
         )
     {
-        status = [QQApiInterface SendReqToQZone:request];
+        if ([message isMemberOfClass:[DTTextMessage class]] || [message isMemberOfClass:[DTImageMessage class]])
+        {
+            apiObject.cflag = kQQAPICtrlFlagQZoneShareOnStart;
+            status = [QQApiInterface sendReq:request];
+        }
+        else
+        {
+            status = [QQApiInterface SendReqToQZone:request];
+        }
     }
     else
     {
+        apiObject.cflag = kQQAPICtrlFlagQQShare;
         status = [QQApiInterface sendReq:request];
     }
     


### PR DESCRIPTION
纯文本和纯图片是不能分享到QQZone，所以硬是要这么做，则可以执行

```
apiObject.cflag = kQQAPICtrlFlagQZoneShareOnStart;
status = [QQApiInterface sendReq:request];
```

以达到分享到QQZone的目的，但以纯文本方式分享到QQZone，只会产生一条记录，文本还是不能显示出来的。
