### PR TITLE
update Wecaht SDK to 1.7.3

### DIFF
--- a/Sources/Wechat/README.txt
+++ b/Sources/Wechat/README.txt
@@ -1,5 +1,12 @@
 重要!
 
+SDK1.7.3
+1. 增强稳定性，适配iOS10
+2. 修复小于32K的jpg格式缩略图设置失败的问题
+
+SDK1.7.2
+1. 修复因CTTeleponyNetworkInfo引起的崩溃问题
+
 SDK1.7.1
 1. 支持兼容ipv6(提升稳定性)
 2. xCode Version 7.3.1 (7D1014) 编译


### PR DESCRIPTION
1.7.3 Wecaht SDK “小于32K的jpg格式缩略图设置失败的问题” fixed
